### PR TITLE
Fix deployment with docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
     environment:
     - MINIO_ROOT_USER=${S3_USER}
     - MINIO_ROOT_PASSWORD=${S3_PASSWORD}
+    restart: on-failure
     volumes:
     - type: bind
       source: ./etc/minio/setup.py

--- a/etc/minio/setup.py
+++ b/etc/minio/setup.py
@@ -23,7 +23,7 @@ def main():
     minio_url = f"http://{minio_endpoint}"
 
     logging.info("Create SSH host key")
-    os.system("ssh-keygen -q -N " " -t rsa -b 4096 -f /keys/ssh_host_rsa_key")
+    os.system('ssh-keygen -q -N "" -t rsa -b 4096 -f /keys/ssh_host_rsa_key')
 
     logging.info("Create host alias")
     os.system(


### PR DESCRIPTION
- Fix string escaping in ssh-keygen command
- Let minio-setup restart on failure as dependance on minio service might result in an error, if the service is started, but not fully initialized yet.