### PR TITLE
Add topic specific callbacks for MQTT broker client

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,3 +38,11 @@ dependencies = {file = ["requirements.txt"]}
 
 [tool.black]
 line-length = 79
+
+[tool.pytest.ini_options]
+markers = [
+  "broker",
+  "store",
+  "logger",
+  "config"
+]

--- a/seguro/common/broker.py
+++ b/seguro/common/broker.py
@@ -98,7 +98,7 @@ class BrokerClient:
         self.logger.debug("Receive msg: %s - %s", msg.topic, str(msg.payload))
         self.message_queue.put(msg)
 
-    def subscribe(self, topic, callback=""):
+    def subscribe(self, topic, callback=None):
         """Subscribe client to given topic and registering callback (optional).
 
         Arguments:

--- a/seguro/common/broker.py
+++ b/seguro/common/broker.py
@@ -86,6 +86,11 @@ class BrokerClient:
                 exc,
             )
 
+        self.start_listening()
+
+    def __del__(self):
+        self.stop_listening()
+
     def __on_connect(self, client, userdata, flags, rc):
         self.logger.info("Connected with result code %i", rc)
 
@@ -93,10 +98,23 @@ class BrokerClient:
         self.logger.debug("Receive msg: %s - %s", msg.topic, str(msg.payload))
         self.message_queue.put(msg)
 
-    def subscribe(self, topic):
-        """Subscribe client to given topic."""
+    def subscribe(self, topic, callback=""):
+        """Subscribe client to given topic and registering callback (optional).
+
+        Arguments:
+            topic -- topic that is subscribed
+
+        Optional:
+            callback -- callback func that is called on message reception.
+                        If no callback set, the default __on_message is called
+        """
         self.client.subscribe(topic)
-        self.logger.info("Subscribed to %s", topic)
+
+        if callback:
+            self.client.message_callback_add(topic, callback)
+            self.logger.info(
+                "Subscribed to %s with callback-func %s", topic, callback
+            )
 
     def start_listening(self):
         """Start async listening on subscribed topics."""

--- a/seguro/common/test_broker.py
+++ b/seguro/common/test_broker.py
@@ -5,26 +5,37 @@ SPDX-License-Identifier: Apache-2.0
 """
 
 import time
+import pytest
 
 from seguro.common.broker import BrokerClient
 
+# Used to store callback messages
+messages = []
 
+
+def callback(client, userdata, msg):
+    messages.append((msg.topic, msg.payload))
+
+
+@pytest.mark.broker
 def test_broker():
     broker = BrokerClient("pytest-broker")
 
     # Subscribe to topic "mytopic" and start listening in another thread
     broker.subscribe("mytopic")
-    broker.start_listening()
+    broker.subscribe("myCustomTopic", callback)
+    # broker.start_listening()
 
     # Publish messages to topic "mytopic"
     broker.publish("mytopic", "Hello MQTT!")
-    broker.publish("mytopic", "Aaaand another one...")
+    broker.publish("myCustomTopic", "Aaaand another one...")
 
     #  Make sure messages are completely sent...
     time.sleep(1)
 
-    # Read messages are stored in a messageQueue of the client
+    # Read messages on "mytopic" are stored in a messageQueue of the client
     assert broker.message_queue.empty() is False
+    assert messages[0] == ("myCustomTopic", b"Aaaand another one...")
 
     # Read messages directly from client message queue
     while not broker.message_queue.empty():
@@ -33,9 +44,6 @@ def test_broker():
 
     # Note that queue.get() removes messages from queue
     assert broker.message_queue.empty() is True
-
-    # Stop listening for new messages
-    broker.stop_listening()
 
     # Note that messsages send after listening has stopped,
     # are not put into message queue

--- a/seguro/common/test_config.py
+++ b/seguro/common/test_config.py
@@ -1,11 +1,13 @@
 """
 SPDX-FileCopyrightText: 2023 Steffen Vogel, OPAL-RT Germany GmbH
+SPDX-FileCopyrightText: 2023 Felix Wege, EONERC-ACS, RWTH Aachen University
 SPDX-License-Identifier: Apache-2.0
 """
 
-
+import pytest
 from seguro.common.config import S3_BUCKET
 
 
+@pytest.mark.config
 def test_default_config():
     assert S3_BUCKET == "seguro"

--- a/seguro/common/test_logger.py
+++ b/seguro/common/test_logger.py
@@ -6,8 +6,10 @@ SPDX-License-Identifier: Apache-2.0
 import seguro.common.logger
 import logging
 import os
+import pytest
 
 
+@pytest.mark.logger
 def test_file_logger(capsys):
     filepath = os.path.join(
         os.path.dirname(__file__),
@@ -36,6 +38,7 @@ def test_file_logger(capsys):
         os.remove(filepath)
 
 
+@pytest.mark.logger
 def test_store_logger(capsys):
     store_logger = seguro.common.logger.store_logger(logging.DEBUG, "test.log")
     store_logger.error("Test-Error")

--- a/seguro/common/test_store.py
+++ b/seguro/common/test_store.py
@@ -1,14 +1,17 @@
 """
 SPDX-FileCopyrightText: 2023 Steffen Vogel, OPAL-RT Germany GmbH
+SPDX-FileCopyrightText: 2023 Felix Wege, EONERC-ACS, RWTH Aachen University
 SPDX-License-Identifier: Apache-2.0
 """
 
 import os
 import threading
+import pytest
 
 from seguro.common.store import Client, Event, EventType
 
 
+@pytest.mark.store
 def test_store():
     store = Client("pytest-client")
 
@@ -39,6 +42,7 @@ def test_store():
     os.remove("myfile.txt")
 
 
+@pytest.mark.store
 def test_watch():
     store = Client("pytest-client")
 
@@ -64,6 +68,7 @@ def test_watch():
     assert event.filename == filename
 
 
+@pytest.mark.store
 def test_watch_async():
     store = Client("pytest-client")
 


### PR DESCRIPTION
Allows registering individual callback functions for each topic subscribed via the MQTT broker client.

Addresses #22